### PR TITLE
Bump version 3.0.0 to 3.1.0 for action-post-run

### DIFF
--- a/actions/upgrade-archlinux/action.yml
+++ b/actions/upgrade-archlinux/action.yml
@@ -32,6 +32,6 @@ runs:
       run: pacman -Syu --noconfirm
 
     - name: Cleanup pacman cache
-      uses: webiny/action-post-run@3.0.0
+      uses: webiny/action-post-run@3.1.0
       with:
         run: pacman -Sc --noconfirm


### PR DESCRIPTION
Related with https://github.com/webiny/action-post-run/pull/8